### PR TITLE
Consistently use tuples instead of lists for actions

### DIFF
--- a/rgkit/game.py
+++ b/rgkit/game.py
@@ -175,7 +175,7 @@ class Player(object):
         except:
             exc_flag = True
             traceback.print_exc(file=sys.stderr)
-            action = ['guard']
+            action = ('guard',)
 
         finally:
             sys.stdout = _stdout


### PR DESCRIPTION
Actions are converted to tuples, but ['guard'] is returned for invalid ones. Replace it with ('guard',).