### PR TITLE
show a more helpful message to users if there is a import error on tk…

### DIFF
--- a/rgkit/render/render.py
+++ b/rgkit/render/render.py
@@ -1,8 +1,20 @@
 from __future__ import division
+
+import sys
 try:
     import Tkinter
 except ImportError:
-    import tkinter as Tkinter
+    try:
+        import tkinter as Tkinter
+    except ImportError:
+        sys.exit(
+            "\033[1;31m"+'rgrun has problem importing tkinter, '
+            'which rgrun GUI is dependent on by default. \n'
+            'Tkinter is likely not installed or '
+            'configured incorrectly. \n'
+            'Alternatively, you can try running rgrun as '
+            'headless (-H) or use text base UI (-C).'+"\033[0m")
+
 import math
 
 from rgkit.settings import settings

--- a/rgkit/run.py
+++ b/rgkit/run.py
@@ -382,33 +382,11 @@ def print_score_grid(scores, player1, player2, size):
         print(str2)
 
 
-def check_tkinter(args):
-    if not args.headless and not args.curses:
-        try:
-            import Tkinter
-            return
-        except ImportError:
-            pass
-        try:
-            import tkinter as Tkinter
-            return
-        except ImportError:
-            sys.exit(
-                "\033[1;31m"+'rgrun has problem importing tkinter, '
-                'which rgrun GUI is dependent on by default. \n'
-                'Tkinter is likely not installed or '
-                'configured incorrectly. \n'
-                'Alternatively, you can try running rgrun as '
-                'headless (-H) or use text base UI (-C).'+"\033[0m")
-
-
 def main():
     args = get_arg_parser().parse_args()
 
     if "nice" in args:
         os.nice(args.nice)
-
-    check_tkinter(args)
 
     num_opponents = len(args.opponents)
     total_won, total_lost, total_draw, total_avg_score, total_diff = (

--- a/rgkit/run.py
+++ b/rgkit/run.py
@@ -382,11 +382,33 @@ def print_score_grid(scores, player1, player2, size):
         print(str2)
 
 
+def check_tkinter(args):
+    if not args.headless and not args.curses:
+        try:
+            import Tkinter
+            return
+        except ImportError:
+            pass
+        try:
+            import tkinter as Tkinter
+            return
+        except ImportError:
+            sys.exit(
+                "\033[1;31m"+'rgrun has problem importing tkinter, '
+                'which rgrun GUI is dependent on by default. \n'
+                'Tkinter is likely not installed or '
+                'configured incorrectly. \n'
+                'Alternatively, you can try running rgrun as '
+                'headless (-H) or use text base UI (-C).'+"\033[0m")
+
+
 def main():
     args = get_arg_parser().parse_args()
 
     if "nice" in args:
         os.nice(args.nice)
+
+    check_tkinter(args)
 
     num_opponents = len(args.opponents)
     total_won, total_lost, total_draw, total_avg_score, total_diff = (


### PR DESCRIPTION
I do believe that users could benefit with a slightly more informative error message about tkinker, as I do not think tkinker is installed by default (say in Macs and Ubuntu).

I have included a possible solution on this:  if the options are not headless or curses, then it attempts to load tkinker, and if the import fails, it exits with a message before running the rest of the main script.

It would be great if this will be of any use.  I will be happy for any feedbacks anyhow.  Thanks.

